### PR TITLE
A fix for proxy issues when mixing '/' and '%2F' in URIs.

### DIFF
--- a/angular-cornercouch.js
+++ b/angular-cornercouch.js
@@ -22,7 +22,7 @@ factory('cornercouch', ['$http', function($http) {
         var uri = base;
         if (part1) uri = uri + "/" + encodeURIComponent(part1);
         if (part2) uri = uri + "/" + encodeURIComponent(part2);
-        return uri;
+        return uri.replace('%2F', '/');
     }
 
     // Database-level constructor


### PR DESCRIPTION
CornerCouch tends to produce URIs with `%2F`, e.g.`/database/_design%2Fapp`, and this causes certain problems with proxies and URL rewrites which fail to match URL against rules with `/` chars. For example, simplest CouchDB proxy using node.js http-proxy module will expose this problem.

With this pull request I'm adding minimal and "brute-force" solution: replace all `%2F` with `/` in URIs, and this solves all problems on my local server.
