### PR TITLE
Feature request: Add Bower json file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,6 @@
     "bower_components"
   ],
   "dependencies": {
-    "angular": "1.0.3"
+    "angular": "~1.0.3"
   }
 }


### PR DESCRIPTION
Using bower.json to track against angular version 1.0.3.

Bower is a front-end package manager, see http://bower.io for information.

Adding the bower.json file warns the user if they try to use CornerCouch with an incompatible version of angular (dependencies), and highlights the file to include in their application (main).

If you decide to start [tagging releases of CornerCouch with Semantic Versioning](http://semver.org/), users will be able to install specific versions of CornerCouch too, e.g. if a newer release requires a newer version of angular than other packages the user might be using in their project.

If you decide not to include a bower.json then users will still be able to install the latest version of CornerCouch via Bower but will not be warned if they attempt to use it with an older or much newer version of angular.

Thanks
 RRaven
